### PR TITLE
Added auth module with csrf cookie resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ Then in python shell initialize the client (if you're using chrome, cookies can 
 import leetcode
 
 # Get the next two values from your browser cookies
-csrf_token = "xxx"
 leetcode_session = "yyy"
+csrf_token = "xxx"
+
+# Experimental: Or CSRF token can be obtained automatically
+import leetcode.auth
+csrf_token = leetcode.auth.get_csrf_cookie(leetcode_session)
 
 configuration = leetcode.Configuration()
 

--- a/leetcode/auth.py
+++ b/leetcode/auth.py
@@ -1,0 +1,12 @@
+import requests
+
+
+def get_csrf_cookie(session_id: str) -> str:
+    response = requests.get(
+        "https://leetcode.com/",
+        cookies={
+            "LEETCODE_SESSION": session_id,
+        },
+    )
+
+    return response.cookies["csrftoken"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ six >= 1.10
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.15.1
+requests


### PR DESCRIPTION
CSRF token becomes invalid once used from another place (GitHub Actions, for example). It is possible to fetch it automatically having a session-id cookie available.